### PR TITLE
Fix Samedec bug

### DIFF
--- a/asmara.py
+++ b/asmara.py
@@ -243,21 +243,13 @@ class AS_MON(Process):
             sev=severity.trace,
         )
         try:
-            if (
-                "samedec 0.2."
+            if not (
+                "samedec 0.1."
                 in Popen(["samedec", "-V"], stdout=PIPE)
                 .communicate()[0]
                 .decode("UTF-8")
                 .strip()
             ):
-                self.__decode__ = Popen(
-                    ["samedec", "-r", "24000"],
-                    stdout=PIPE,
-                    stdin=PIPE,
-                    stderr=PIPE,
-                    bufsize=1,
-                )
-            else:
                 utilities.autoPrint(
                     text=f"SAMEDEC is not version 0.2 or higher! Recommended version is 0.2.3.",
                     classType="DECODER",
@@ -265,6 +257,14 @@ class AS_MON(Process):
                 )
                 AS_MAN.killAsmara()
                 exit(1)
+            else:
+                self.__decode__ = Popen(
+                    ["samedec", "-r", "24000"],
+                    stdout=PIPE,
+                    stdin=PIPE,
+                    stderr=PIPE,
+                    bufsize=1,
+                )
         except FileNotFoundError:
             utilities.autoPrint(
                 text=f"Samedec is not installed on the computer. Please install SAMEDEC 0.2.3 or higher.",


### PR DESCRIPTION
When this was written, SAMEDEC development was slow and on 0.2.3, and we didn't estimate a 3.0 launch then.

Changed the string to check for 0.1.X, instead of 0.2.X, meaning that anything greater than V1 will work.

Needs compatibility checking with V3.